### PR TITLE
Bug: 1950 - Fix IP for example landing zone

### DIFF
--- a/patentanalytics/InitialLoad/Spray_Files.ecl
+++ b/patentanalytics/InitialLoad/Spray_Files.ecl
@@ -3,7 +3,7 @@ import std, std.File, std.Str;
 dirAlias := std.File.FsFilenameRecord;
 
 
-STRING landing_zone := '10.239.20.76';
+STRING landing_zone := '127.0.0.1';		// Change to your Landing Zone IP
 STRING directory := '/var/lib/HPCCSystems/dropzone/patent_data/';
 STRING cluster := 'mythor';
 


### PR DESCRIPTION
Changed IP for landing zone in spray example to loop back address and added comment to change it.

Signed-off-by: John Holt holtjd@BCTDW7HOLTJD.risk.regn.net
