### PR TITLE
Fixed html lt and gt in MLUsageExamples

### DIFF
--- a/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.Accuracy.ecl
+++ b/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.Accuracy.ecl
@@ -26,8 +26,8 @@
              ,TRANSFORM(ML.Types.NumericField
                         ,SELF.Number:=4
                         ,SELF.Value:=
-                                MAP(LEFT.Val &lt; 6 =&gt; 0
-                                    ,LEFT.VAL &lt; 10 =&gt; 1
+                                MAP(LEFT.Val < 6 => 0
+                                    ,LEFT.VAL < 10 => 1
                                     ,2
                                 )
                         ,SELF := LEFT
@@ -38,8 +38,8 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   model:=ML.Classify.NaiveBayes.LearnD(D2(Number&lt;=3),D2(Number=4));
-   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number&lt;=3),model);
+   model:=ML.Classify.NaiveBayes.LearnD(D2(Number<=3),D2(Number=4));
+   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number<=3),model);
    OUTPUT(predictions,NAMED('predictions'));
 
    cmp:=ML.Classify.Compare(D2(Number=4),predictions);

--- a/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.CrossAssignments.ecl
+++ b/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.CrossAssignments.ecl
@@ -26,8 +26,8 @@
              ,TRANSFORM(ML.Types.NumericField
                         ,SELF.Number:=4
                         ,SELF.Value:=
-                                MAP(LEFT.Val &lt; 6 =&gt; 0
-                                    ,LEFT.VAL &lt; 10 =&gt; 1
+                                MAP(LEFT.Val < 6 => 0
+                                    ,LEFT.VAL < 10 => 1
                                     ,2
                                 )
                         ,SELF := LEFT
@@ -38,8 +38,8 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   model:=ML.Classify.NaiveBayes.LearnD(D2(Number&lt;=3),D2(Number=4));
-   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number&lt;=3),model);
+   model:=ML.Classify.NaiveBayes.LearnD(D2(Number<=3),D2(Number=4));
+   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number<=3),model);
    OUTPUT(predictions,NAMED('predictions'));
 
    cmp:=ML.Classify.Compare(D2(Number=4),predictions);

--- a/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.FP_Rate_ByClass.ecl
+++ b/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.FP_Rate_ByClass.ecl
@@ -26,8 +26,8 @@
              ,TRANSFORM(ML.Types.NumericField
                         ,SELF.Number:=4
                         ,SELF.Value:=
-                                MAP(LEFT.Val &lt; 6 =&gt; 0
-                                    ,LEFT.VAL &lt; 10 =&gt; 1
+                                MAP(LEFT.Val < 6 => 0
+                                    ,LEFT.VAL < 10 => 1
                                     ,2
                                 )
                         ,SELF := LEFT
@@ -38,8 +38,8 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   model:=ML.Classify.NaiveBayes.LearnD(D2(Number&lt;=3),D2(Number=4));
-   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number&lt;=3),model);
+   model:=ML.Classify.NaiveBayes.LearnD(D2(Number<=3),D2(Number=4));
+   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number<=3),model);
    OUTPUT(predictions,NAMED('predictions'));
 
    cmp:=ML.Classify.Compare(D2(Number=4),predictions);

--- a/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.HeadLine.ecl
+++ b/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.HeadLine.ecl
@@ -26,8 +26,8 @@
              ,TRANSFORM(ML.Types.NumericField
                         ,SELF.Number:=4
                         ,SELF.Value:=
-                                MAP(LEFT.Val &lt; 6 =&gt; 0
-                                    ,LEFT.VAL &lt; 10 =&gt; 1
+                                MAP(LEFT.Val < 6 => 0
+                                    ,LEFT.VAL < 10 => 1
                                     ,2
                                 )
                         ,SELF := LEFT
@@ -38,8 +38,8 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   model:=ML.Classify.NaiveBayes.LearnD(D2(Number&lt;=3),D2(Number=4));
-   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number&lt;=3),model);
+   model:=ML.Classify.NaiveBayes.LearnD(D2(Number<=3),D2(Number=4));
+   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number<=3),model);
    OUTPUT(predictions,NAMED('predictions'));
 
    cmp:=ML.Classify.Compare(D2(Number=4),predictions);

--- a/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.PrecisionByClass.ecl
+++ b/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.PrecisionByClass.ecl
@@ -26,8 +26,8 @@
              ,TRANSFORM(ML.Types.NumericField
                         ,SELF.Number:=4
                         ,SELF.Value:=
-                                MAP(LEFT.Val &lt; 6 =&gt; 0
-                                    ,LEFT.VAL &lt; 10 =&gt; 1
+                                MAP(LEFT.Val < 6 => 0
+                                    ,LEFT.VAL < 10 => 1
                                     ,2
                                 )
                         ,SELF := LEFT
@@ -38,8 +38,8 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   model:=ML.Classify.NaiveBayes.LearnD(D2(Number&lt;=3),D2(Number=4));
-   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number&lt;=3),model);
+   model:=ML.Classify.NaiveBayes.LearnD(D2(Number<=3),D2(Number=4));
+   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number<=3),model);
    OUTPUT(predictions,NAMED('predictions'));
 
    cmp:=ML.Classify.Compare(D2(Number=4),predictions);

--- a/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.Raw.ecl
+++ b/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.Raw.ecl
@@ -27,8 +27,8 @@
              ,TRANSFORM(ML.Types.NumericField
                         ,SELF.Number:=4
                         ,SELF.Value:=
-                                MAP(LEFT.Val &lt; 6 =&gt; 0
-                                    ,LEFT.VAL &lt; 10 =&gt; 1
+                                MAP(LEFT.Val < 6 => 0
+                                    ,LEFT.VAL < 10 => 1
                                     ,2
                                 )
                         ,SELF := LEFT
@@ -39,8 +39,8 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   model:=ML.Classify.NaiveBayes.LearnD(D2(Number&lt;=3),D2(Number=4));
-   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number&lt;=3),model);
+   model:=ML.Classify.NaiveBayes.LearnD(D2(Number<=3),D2(Number=4));
+   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number<=3),model);
    OUTPUT(predictions,NAMED('predictions'));
 
    cmp:=ML.Classify.Compare(D2(Number=4),predictions);

--- a/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.RecallByClass.ecl
+++ b/MLUsageExamples/Classify/Compare/Use_ML.Classify.Compare.RecallByClass.ecl
@@ -26,8 +26,8 @@
              ,TRANSFORM(ML.Types.NumericField
                         ,SELF.Number:=4
                         ,SELF.Value:=
-                                MAP(LEFT.Val &lt; 6 =&gt; 0
-                                    ,LEFT.VAL &lt; 10 =&gt; 1
+                                MAP(LEFT.Val < 6 => 0
+                                    ,LEFT.VAL < 10 => 1
                                     ,2
                                 )
                         ,SELF := LEFT
@@ -38,8 +38,8 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   model:=ML.Classify.NaiveBayes.LearnD(D2(Number&lt;=3),D2(Number=4));
-   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number&lt;=3),model);
+   model:=ML.Classify.NaiveBayes.LearnD(D2(Number<=3),D2(Number=4));
+   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number<=3),model);
    OUTPUT(predictions,NAMED('predictions'));
 
    cmp:=ML.Classify.Compare(D2(Number=4),predictions);

--- a/MLUsageExamples/Classify/Logistic/Use_ML.Classify.Logistic.ClassifyC.ecl
+++ b/MLUsageExamples/Classify/Logistic/Use_ML.Classify.Logistic.ClassifyC.ecl
@@ -39,6 +39,6 @@
    flds1 := flds0+f4;
    flds := ML.Discretize.ByRounding(flds1);
 
-   Model3 := ML.Classify.Logistic().LearnC(flds1(Number&lt;=2),flds(Number=3));
-   predict:=ML.Classify.Logistic().ClassifyC(flds1(Number&lt;=2),Model3);
+   Model3 := ML.Classify.Logistic().LearnC(flds1(Number<=2),flds(Number=3));
+   predict:=ML.Classify.Logistic().ClassifyC(flds1(Number<=2),Model3);
    OUTPUT(predict,NAMED('predict'));

--- a/MLUsageExamples/Classify/Logistic/Use_ML.Classify.Logistic.ClassifyD.ecl
+++ b/MLUsageExamples/Classify/Logistic/Use_ML.Classify.Logistic.ClassifyD.ecl
@@ -38,8 +38,8 @@
    flds1 := flds0+f4;
    flds := ML.Discretize.ByRounding(flds1);
 
-   Model3 := ML.Classify.Logistic().LearnD(flds(Number&lt;=2),flds(Number=3));
+   Model3 := ML.Classify.Logistic().LearnD(flds(Number<=2),flds(Number=3));
    OUTPUT(Model3,NAMED('Model3'));
 
-   predict:=ML.Classify.Logistic().ClassifyD(flds(Number&lt;=2),Model3);
+   predict:=ML.Classify.Logistic().ClassifyD(flds(Number<=2),Model3);
    OUTPUT(predict,NAMED('predict'));

--- a/MLUsageExamples/Classify/Logistic/Use_ML.Classify.Logistic.LearnC.ecl
+++ b/MLUsageExamples/Classify/Logistic/Use_ML.Classify.Logistic.LearnC.ecl
@@ -42,5 +42,5 @@
    flds1 := flds0+f4;
    flds := ML.Discretize.ByRounding(flds1);
 
-   Model3 := ML.Classify.Logistic().LearnC(flds1(Number&lt;=2),flds(Number&gt;=3));
+   Model3 := ML.Classify.Logistic().LearnC(flds1(Number<=2),flds(Number>=3));
    OUTPUT(Model3,NAMED('Model3'));

--- a/MLUsageExamples/Classify/Logistic/Use_ML.Classify.Logistic.LearnD.ecl
+++ b/MLUsageExamples/Classify/Logistic/Use_ML.Classify.Logistic.LearnD.ecl
@@ -36,5 +36,5 @@
    flds1 := flds0+f4;
    flds := ML.Discretize.ByRounding(flds1);
 
-   Model3 := ML.Classify.Logistic().LearnD(flds(Number&lt;=2),flds(Number=3));
+   Model3 := ML.Classify.Logistic().LearnD(flds(Number<=2),flds(Number=3));
    OUTPUT(Model3,NAMED('Model3'));

--- a/MLUsageExamples/Classify/Logistic/Use_ML.Classify.Logistic.TestD.ecl
+++ b/MLUsageExamples/Classify/Logistic/Use_ML.Classify.Logistic.TestD.ecl
@@ -38,5 +38,5 @@
    flds1 := flds0+f4;
    flds := ML.Discretize.ByRounding(flds1);
 
-   comparison := ML.Classify.Logistic().TestD(flds(Number&lt;=2),flds(Number=3));
+   comparison := ML.Classify.Logistic().TestD(flds(Number<=2),flds(Number=3));
    OUTPUT(comparison);

--- a/MLUsageExamples/Classify/NaiveBayes/Use_ML.Classify.NaiveBayes.ClassifyD.ecl
+++ b/MLUsageExamples/Classify/NaiveBayes/Use_ML.Classify.NaiveBayes.ClassifyD.ecl
@@ -30,8 +30,8 @@
               ,TRANSFORM(ML.Types.NumericField
                          ,SELF.Number:=4
                          ,SELF.Value:=
-                              MAP(LEFT.Val &lt; 6 =&gt; 0
-                                 ,LEFT.VAL &lt; 10 =&gt; 1
+                              MAP(LEFT.Val < 6 => 0
+                                 ,LEFT.VAL < 10 => 1
                                  ,2
                               )
                          ,SELF := LEFT
@@ -43,8 +43,8 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   Model := ML.Classify.NaiveBayes.LearnD(D2(Number&lt;=3),D2(Number=4));
+   Model := ML.Classify.NaiveBayes.LearnD(D2(Number<=3),D2(Number=4));
    OUTPUT(Model,NAMED('Model'));
 
-   predict:=ML.Classify.NaiveBayes.ClassifyD(D2(Number&lt;=3),Model);
+   predict:=ML.Classify.NaiveBayes.ClassifyD(D2(Number<=3),Model);
    OUTPUT(predict,NAMED('predict'));

--- a/MLUsageExamples/Classify/NaiveBayes/Use_ML.Classify.NaiveBayes.LearnD.ecl
+++ b/MLUsageExamples/Classify/NaiveBayes/Use_ML.Classify.NaiveBayes.LearnD.ecl
@@ -28,8 +28,8 @@
               ,TRANSFORM(ML.Types.NumericField
                          ,SELF.Number:=4
                          ,SELF.Value:=
-                              MAP(LEFT.Val &lt; 6 =&gt; 0
-                                 ,LEFT.VAL &lt; 10 =&gt; 1
+                              MAP(LEFT.Val < 6 => 0
+                                 ,LEFT.VAL < 10 => 1
                                  ,2
                               )
                          ,SELF := LEFT
@@ -41,5 +41,5 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   Model := ML.Classify.NaiveBayes.LearnD(D2(Number&lt;=3),D2(Number=4));
+   Model := ML.Classify.NaiveBayes.LearnD(D2(Number<=3),D2(Number=4));
    OUTPUT(Model,NAMED('Model'));

--- a/MLUsageExamples/Classify/NaiveBayes/Use_ML.Classify.NaiveBayes.TestD.ecl
+++ b/MLUsageExamples/Classify/NaiveBayes/Use_ML.Classify.NaiveBayes.TestD.ecl
@@ -30,8 +30,8 @@
               ,TRANSFORM(ML.Types.NumericField
                          ,SELF.Number:=4
                          ,SELF.Value:=
-                              MAP(LEFT.Val &lt; 6 =&gt; 0
-                                 ,LEFT.VAL &lt; 10 =&gt; 1
+                              MAP(LEFT.Val < 6 => 0
+                                 ,LEFT.VAL < 10 => 1
                                  ,2
                               )
                          ,SELF := LEFT
@@ -43,5 +43,5 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   comparison := ML.Classify.NaiveBayes.TestD(D2(Number&lt;=3),D2(Number=4));
+   comparison := ML.Classify.NaiveBayes.TestD(D2(Number<=3),D2(Number=4));
    OUTPUT(comparison);

--- a/MLUsageExamples/Classify/Perceptron/Use_ML.Classify.Perceptron.ClassifyD.ecl
+++ b/MLUsageExamples/Classify/Perceptron/Use_ML.Classify.Perceptron.ClassifyD.ecl
@@ -19,10 +19,10 @@
               ],{ UNSIGNED id,UNSIGNED a, UNSIGNED b, UNSIGNED c, UNSIGNED d });
    ML.ToField(d,o);
 
-   o1 := ML.Discretize.ByRounding(o)(id&lt;5);
+   o1 := ML.Discretize.ByRounding(o)(id<5);
 
-   Model:=ML.Classify.Perceptron(9).LearnD(o1(Number&lt;=2),o1(number&gt;=3));
+   Model:=ML.Classify.Perceptron(9).LearnD(o1(Number<=2),o1(number>=3));
    OUTPUT(Model,NAMED('Model'));
 
-   predict:=ML.Classify.Perceptron(9).ClassifyD(o1(Number&lt;=2),Model);
+   predict:=ML.Classify.Perceptron(9).ClassifyD(o1(Number<=2),Model);
    OUTPUT(predict,NAMED('predict'));

--- a/MLUsageExamples/Classify/Perceptron/Use_ML.Classify.Perceptron.LearnD.ecl
+++ b/MLUsageExamples/Classify/Perceptron/Use_ML.Classify.Perceptron.LearnD.ecl
@@ -17,7 +17,7 @@
               ],{ UNSIGNED id,UNSIGNED a, UNSIGNED b, UNSIGNED c, UNSIGNED d });
    ML.ToField(d,o);
 
-   o1 := ML.Discretize.ByRounding(o)(id&lt;5);
+   o1 := ML.Discretize.ByRounding(o)(id<5);
 
-   Model:=ML.Classify.Perceptron(9).LearnD(o1(Number&lt;=2),o1(number&gt;=3));
+   Model:=ML.Classify.Perceptron(9).LearnD(o1(Number<=2),o1(number>=3));
    OUTPUT(Model,NAMED('Model'));

--- a/MLUsageExamples/Classify/Perceptron/Use_ML.Classify.Perceptron.TestD.ecl
+++ b/MLUsageExamples/Classify/Perceptron/Use_ML.Classify.Perceptron.TestD.ecl
@@ -19,7 +19,7 @@
               ],{ UNSIGNED id,UNSIGNED a, UNSIGNED b, UNSIGNED c, UNSIGNED d });
    ML.ToField(d,o);
 
-   o1 := ML.Discretize.ByRounding(o)(id&lt;5);
+   o1 := ML.Discretize.ByRounding(o)(id<5);
 
-   Comparison:=ML.Classify.Perceptron(9).TestD(o1(Number&lt;=2),o1(number&gt;=3));
+   Comparison:=ML.Classify.Perceptron(9).TestD(o1(Number<=2),o1(number>=3));
    OUTPUT(comparison);

--- a/MLUsageExamples/Classify/Use_ML.Classify.Compare.ecl
+++ b/MLUsageExamples/Classify/Use_ML.Classify.Compare.ecl
@@ -25,8 +25,8 @@
              ,TRANSFORM(ML.Types.NumericField
                         ,SELF.Number:=4
                         ,SELF.Value:=
-                                MAP(LEFT.Val &lt; 6 =&gt; 0
-                                    ,LEFT.VAL &lt; 10 =&gt; 1
+                                MAP(LEFT.Val < 6 => 0
+                                    ,LEFT.VAL < 10 => 1
                                     ,2
                                 )
                         ,SELF := LEFT
@@ -37,8 +37,8 @@
    D2 := ML.Discretize.ByRounding(D1);
    OUTPUT(D2,NAMED('D2'));
 
-   model:=ML.Classify.NaiveBayes.LearnD(D2(Number&lt;=3),D2(Number=4));
-   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number&lt;=3),model);
+   model:=ML.Classify.NaiveBayes.LearnD(D2(Number<=3),D2(Number=4));
+   predictions:=ML.Classify.NaiveBayes.ClassifyD(D2(Number<=3),model);
    OUTPUT(predictions,NAMED('predictions'));
 
    cmp:=ML.Classify.Compare(D2(Number=4),predictions);

--- a/MLUsageExamples/README.txt
+++ b/MLUsageExamples/README.txt
@@ -1,16 +1,14 @@
 Written 2013/08/16.
 
-MLUsageExamples contains small example ECL programs that illustrate how to use the functions
-and macros in the Machine Learning (ML) library. Each of these examples are stand-alone except
-for the need of ML. To execute any of them, you only need the ML library in your repository.
+I have placed Machine Learning (ML) example programs on github: https://github.com/hpcc-systems/ecl-samples. They are in the folder MLUsageExamples.
 
-The number of example programs in this bundle will increase over time.
+These are small example ECL programs that illustrate how to use the functions and macros in the Machine Learning (ML) library. Each of these examples are stand-alone except for the need of ML. To execute any of them, you only need the ML library in your repository.
+
+There are more than 200 example programs. Furthermore, the number of example programs will increase over time. I will post again when I add additional programs.
+
+In MLUsageExamples, there is a README.txt file that tells a little about the organization of these example programs.
 
 ORGANIZATION
 
-The folders in this bundle are organized like the ML library's folder structure. For example
-an example of how to use ML.Mat.Add will be found in the Mat folder because ML.Mat.Add.ecl
-is in the ML/Mat folder of the ML library. Furthermore, modules of the ML library
-will have  examples in a folder named after the module. For example, examples of how to use
-the functions of the ML.Mat.Each.ecl module will be found in the folder MLUsageExamples/Mat/Each.
+MLUsageExamples is organized like the ML library's folder structure. For example an example of how to use ML.Mat.Add will be found in the Mat folder because ML.Mat.Add.ecl is in the ML/Mat folder of the ML library. Furthermore, modules of the ML library will have  examples in a folder named after the module. For example, examples of how to use the functions of the ML.Mat.Each.ecl module will be found in the folder MLUsageExamples/Mat/Each.
   


### PR DESCRIPTION
Fixed html &lt; and &gt; so they are '<' and '>'. Plus, changed some of the wording in README.txt
