### PR TITLE
Cross Browser Support updates

### DIFF
--- a/visualizations/google_charts/files/charts_view.xslt
+++ b/visualizations/google_charts/files/charts_view.xslt
@@ -31,13 +31,12 @@
     <xsl:include href="sparklinechart.xslt"/>
     <xsl:include href="scatterchart.xslt"/>
     <xsl:template match="/">
-		<xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
+        <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
         <xsl:apply-templates select="*/Results/Result"/>
     </xsl:template>
     <xsl:template match="Result">
         <html>
             <head>
-                
                 <title>ECL Workunit Web View using Google Visualization API.                 </title>
                 <script type="text/javascript" src="http://www.google.com/jsapi"> </script>
                 <script type="text/javascript"><xsl:text>

--- a/visualizations/google_charts/files/editor_view.xslt
+++ b/visualizations/google_charts/files/editor_view.xslt
@@ -22,7 +22,7 @@
     <xsl:include href="json_chart_data.xslt"/>
     <xsl:include href="editor.xslt"/>
     <xsl:template match="/">
-		<xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
+        <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
         <xsl:apply-templates select="*/Results/Result"/>
     </xsl:template>
     <xsl:template match="Result">


### PR DESCRIPTION
The rendered webpage was missing the <!DOCTYPE html> tag at the start of the source code.  This caused the page to be rendered incorrectly in certain browsers specifically in the eclipse and other SWT based browsers. 
